### PR TITLE
Fix flatpak proxy

### DIFF
--- a/roles/frontend/defaults/main.yml
+++ b/roles/frontend/defaults/main.yml
@@ -15,4 +15,4 @@ frontend_nginx_ssl_name: "{{ inventory_hostname }}"
 frontend_nginx_webroot_domain: flathub.org
 frontend_nginx_webroot_origin: https://front.flathub.org
 frontend_nginx_flatpak_domain: flatpak.org
-frontend_nginx_flatpak_origin: https://front.flathub.org
+frontend_nginx_flatpak_origin: https://flatpak.webapps.flathub.org

--- a/roles/frontend/templates/nginx-conf.d-flatpak-ssl.conf.j2
+++ b/roles/frontend/templates/nginx-conf.d-flatpak-ssl.conf.j2
@@ -18,12 +18,6 @@ server {
       proxy_pass {{ frontend_nginx_flatpak_origin }};
     }
 
-    # Maintain disabling of gzip for svgz files
-    location ~* \.svgz$ {
-      gzip off;
-      add_header Content-Encoding "gzip";
-    }
-
     # certs sent to the client in SERVER HELLO are concatenated in ssl_certificate
     ssl_certificate /var/lib/certsync/certs/{{ frontend_nginx_flatpak_domain }}/fullchain.pem;
     ssl_certificate_key /var/lib/certsync/certs/{{ frontend_nginx_flatpak_domain }}/privkey.pem;


### PR DESCRIPTION
Use a unique domain so that proxying over https:// finds a server providing the proper certificate.

Fixes flathub/flathub#707.