### PR TITLE
Forward ACME challenges over HTTP

### DIFF
--- a/roles/frontend/defaults/main.yml
+++ b/roles/frontend/defaults/main.yml
@@ -13,6 +13,6 @@ frontend_nginx_repo_origin_server: http://repo.flathub.org
 frontend_nginx_resolver: 8.8.8.8
 frontend_nginx_ssl_name: "{{ inventory_hostname }}"
 frontend_nginx_webroot_domain: flathub.org
-frontend_nginx_webroot_origin: https://front.flathub.org
+frontend_nginx_webroot_origin: front.flathub.org
 frontend_nginx_flatpak_domain: flatpak.org
-frontend_nginx_flatpak_origin: https://flatpak.webapps.flathub.org
+frontend_nginx_flatpak_origin: flatpak.webapps.flathub.org

--- a/roles/frontend/templates/nginx-conf.d-dl-default.conf.j2
+++ b/roles/frontend/templates/nginx-conf.d-dl-default.conf.j2
@@ -8,7 +8,7 @@ server {
     include /etc/nginx/default.d/repo.conf;
 
     location /.well-known/acme-challenge {
-      proxy_pass {{ frontend_nginx_webroot_origin }}/.well-known/acme-challenge;
+      proxy_pass http://{{ frontend_nginx_webroot_origin }}/.well-known/acme-challenge;
       proxy_hide_header Strict-Transport-Security;
       proxy_hide_header Vary;
     }

--- a/roles/frontend/templates/nginx-conf.d-dl-ssl.conf.j2
+++ b/roles/frontend/templates/nginx-conf.d-dl-ssl.conf.j2
@@ -7,12 +7,6 @@ server {
     # Load configuration files for the default server block.
     include /etc/nginx/default.d/repo.conf;
 
-    location /.well-known/acme-challenge {
-      proxy_pass {{ frontend_nginx_webroot_origin }}/.well-known/acme-challenge;
-      proxy_hide_header Strict-Transport-Security;
-      proxy_hide_header Vary;
-    }
-
     # Everything else to https://{{ frontend_nginx_webroot_domain }} for the time being
     location / {
       return 302 https://{{ frontend_nginx_webroot_domain }}$request_uri;

--- a/roles/frontend/templates/nginx-conf.d-flatpak-default.conf.j2
+++ b/roles/frontend/templates/nginx-conf.d-flatpak-default.conf.j2
@@ -5,7 +5,7 @@ server {
     server_name {{ frontend_nginx_flatpak_domain }} www.{{ frontend_nginx_flatpak_domain }};
 
     location /.well-known/acme-challenge {
-      proxy_pass {{ frontend_nginx_flatpak_origin }}/.well-known/acme-challenge;
+      proxy_pass http://{{ frontend_nginx_flatpak_origin }}/.well-known/acme-challenge;
       proxy_hide_header Strict-Transport-Security;
       proxy_hide_header Vary;
     }

--- a/roles/frontend/templates/nginx-conf.d-flatpak-ssl.conf.j2
+++ b/roles/frontend/templates/nginx-conf.d-flatpak-ssl.conf.j2
@@ -4,18 +4,12 @@ server {
 
     server_name {{ frontend_nginx_flatpak_domain }} www.{{ frontend_nginx_flatpak_domain }};
 
-    location /.well-known/acme-challenge {
-      proxy_pass {{ frontend_nginx_flatpak_origin }}/.well-known/acme-challenge;
-      proxy_hide_header Strict-Transport-Security;
-      proxy_hide_header Vary;
-    }
-
     location / {
       proxy_cache frontend_cache;
       proxy_hide_header Strict-Transport-Security;
       proxy_hide_header Vary;
       proxy_set_header Host $host;
-      proxy_pass {{ frontend_nginx_flatpak_origin }};
+      proxy_pass https://{{ frontend_nginx_flatpak_origin }};
     }
 
     # certs sent to the client in SERVER HELLO are concatenated in ssl_certificate

--- a/roles/frontend/templates/nginx-conf.d-webroot-default.conf.j2
+++ b/roles/frontend/templates/nginx-conf.d-webroot-default.conf.j2
@@ -4,7 +4,7 @@ server {
     server_name  {{ frontend_nginx_webroot_domain }} www.{{ frontend_nginx_webroot_domain }};
 
     location /.well-known/acme-challenge {
-      proxy_pass {{ frontend_nginx_webroot_origin }}/.well-known/acme-challenge;
+      proxy_pass http://{{ frontend_nginx_webroot_origin }}/.well-known/acme-challenge;
       proxy_hide_header Strict-Transport-Security;
       proxy_hide_header Vary;
     }

--- a/roles/frontend/templates/nginx-conf.d-webroot-default.conf.j2
+++ b/roles/frontend/templates/nginx-conf.d-webroot-default.conf.j2
@@ -8,6 +8,8 @@ server {
       proxy_hide_header Strict-Transport-Security;
       proxy_hide_header Vary;
     }
-    
-    return 301 https://$host$request_uri;
+
+    location / {
+      return 301 https://$host$request_uri;
+    }
 }

--- a/roles/frontend/templates/nginx-conf.d-webroot-ssl.conf.j2
+++ b/roles/frontend/templates/nginx-conf.d-webroot-ssl.conf.j2
@@ -10,12 +10,6 @@ server {
     include /etc/nginx/default.d/repo.conf;
     include /etc/nginx/default.d/webroot.conf;
 
-    location /.well-known/acme-challenge {
-      proxy_pass {{ frontend_nginx_webroot_origin }}/.well-known/acme-challenge;
-      proxy_hide_header Strict-Transport-Security;
-      proxy_hide_header Vary;
-    }
-
     # certs sent to the client in SERVER HELLO are concatenated in ssl_certificate
     ssl_certificate /var/lib/certsync/certs/{{ frontend_nginx_webroot_domain }}/fullchain.pem;
     ssl_certificate_key /var/lib/certsync/certs/{{ frontend_nginx_webroot_domain }}/privkey.pem;

--- a/roles/frontend/templates/nginx-default.d-webroot.conf.j2
+++ b/roles/frontend/templates/nginx-default.d-webroot.conf.j2
@@ -18,6 +18,6 @@ location / {
         proxy_pass http://prerender;
     }
     if ($prerender = 0) {
-        proxy_pass {{ frontend_nginx_webroot_origin }};
+        proxy_pass https://{{ frontend_nginx_webroot_origin }};
     }
 }


### PR DESCRIPTION
ACME http-01 challenges are always done over HTTP. Using HTTPS would require the server to already have a certificate for the domain that was being validated. Proxy the ACME challenge requests with HTTP and drop the handling from the HTTPS vhosts.