### PR TITLE
base: Pass list of packages instead of looping

### DIFF
--- a/roles/base/tasks/deb.yml
+++ b/roles/base/tasks/deb.yml
@@ -32,8 +32,7 @@
 
 - name: install base packages
   package:
-    name: "{{ item }}"
-  with_items: "{{ base_packages + base_packages_deb }}"
+    name: "{{ base_packages + base_packages_deb }}"
   tags:
    - base
 

--- a/roles/base/tasks/rpm.yml
+++ b/roles/base/tasks/rpm.yml
@@ -27,7 +27,6 @@
 
 - name: install base packages
   package:
-    name: "{{ item }}"
-  with_items: "{{ base_packages + base_packages_rpm }}"
+    name: "{{ base_packages + base_packages_rpm }}"
   tags:
    - base


### PR DESCRIPTION
This is poorly documented[1] or not at all, but all of the package
manager modules take a list of packages in addition to a single package.
It's significantly faster to pass the whole list of base packages to the
package manager once instead of once per package.

1. https://docs.ansible.com/ansible/latest/user_guide/playbooks_loops.html#standard-loops