### PR TITLE
Reduce log retention for the raw stats

### DIFF
--- a/roles/stats/templates/logrotate-flathub-stats.j2
+++ b/roles/stats/templates/logrotate-flathub-stats.j2
@@ -2,7 +2,7 @@
 {{ stats_cache_logs_dir }}/debug.log {
     daily
     nodateext
-    rotate 14
+    rotate 7
     compress
     missingok
     sharedscripts


### PR DESCRIPTION
The stats VM filled up, in connection with logging less detail from Fastly, keep less of the old logs around.