### PR TITLE
linux-store-backend: Allow container to see appstream-extractor dir

### DIFF
--- a/roles/linux-store-backend/tasks/main.yml
+++ b/roles/linux-store-backend/tasks/main.yml
@@ -72,6 +72,14 @@
   tags:
    - linux-store-backend
 
+- name: Allow container to see files in appstream-extractor directory
+  sefcontext:
+    target: '{{ linux_store_backend_apptream_extractor_dir }}(/.*)?'
+    setype: container_file_t
+    state: present
+  tags:
+   - linux-store-backend
+
 - name: create appstream-extractor directory
   file:
     path: "{{ linux_store_backend_apptream_extractor_dir }}"


### PR DESCRIPTION
The container couldn't see the extracted appstream data due to selinux, make it container_file_t