### PR TITLE
Switch from apps.flathub.org to webapps.flathub.org for store API

### DIFF
--- a/roles/frontend/defaults/main.yml
+++ b/roles/frontend/defaults/main.yml
@@ -4,7 +4,7 @@ frontend_certsync_ssh_users:
  - root@front.flathub.org
  - root@webapps.flathub.org
 frontend_nginx_api_servers:
- - apps.flathub.org:8080
+ - webapps.flathub.org:8080
 frontend_nginx_prerender_servers:
  - 45.55.104.129:3000
 frontend_nginx_buildbot_origin: http://master.flathub.org:8010


### PR DESCRIPTION
webapps.flathub.org is now fully up, so we can switch over.