### PR TITLE
Clean up HTTP requests

### DIFF
--- a/roles/frontend/templates/nginx-conf.d-cache.conf.j2
+++ b/roles/frontend/templates/nginx-conf.d-cache.conf.j2
@@ -4,3 +4,4 @@ proxy_cache_path {{ frontend_nginx_cache_dir }} levels=1:2 keys_zone=frontend_ca
 proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
 proxy_cache_revalidate on;
 proxy_cache_purge PURGE from {{ frontend_nginx_cache_purge_from }};
+proxy_hide_header Strict-Transport-Security;

--- a/roles/frontend/templates/nginx-conf.d-dl-default.conf.j2
+++ b/roles/frontend/templates/nginx-conf.d-dl-default.conf.j2
@@ -9,7 +9,6 @@ server {
 
     location /.well-known/acme-challenge {
       proxy_pass http://{{ frontend_nginx_webroot_origin }}/.well-known/acme-challenge;
-      proxy_hide_header Vary;
     }
     
     # Everything else to https://{{ frontend_nginx_webroot_domain }} for the time being

--- a/roles/frontend/templates/nginx-conf.d-dl-default.conf.j2
+++ b/roles/frontend/templates/nginx-conf.d-dl-default.conf.j2
@@ -9,7 +9,6 @@ server {
 
     location /.well-known/acme-challenge {
       proxy_pass http://{{ frontend_nginx_webroot_origin }}/.well-known/acme-challenge;
-      proxy_hide_header Strict-Transport-Security;
       proxy_hide_header Vary;
     }
     

--- a/roles/frontend/templates/nginx-conf.d-flatpak-default.conf.j2
+++ b/roles/frontend/templates/nginx-conf.d-flatpak-default.conf.j2
@@ -6,7 +6,6 @@ server {
 
     location /.well-known/acme-challenge {
       proxy_pass http://{{ frontend_nginx_flatpak_origin }}/.well-known/acme-challenge;
-      proxy_hide_header Strict-Transport-Security;
       proxy_hide_header Vary;
     }
 

--- a/roles/frontend/templates/nginx-conf.d-flatpak-default.conf.j2
+++ b/roles/frontend/templates/nginx-conf.d-flatpak-default.conf.j2
@@ -6,7 +6,6 @@ server {
 
     location /.well-known/acme-challenge {
       proxy_pass http://{{ frontend_nginx_flatpak_origin }}/.well-known/acme-challenge;
-      proxy_hide_header Vary;
     }
 
     location / {

--- a/roles/frontend/templates/nginx-conf.d-flatpak-ssl.conf.j2
+++ b/roles/frontend/templates/nginx-conf.d-flatpak-ssl.conf.j2
@@ -9,7 +9,6 @@ server {
 
     location / {
       proxy_cache frontend_cache;
-      proxy_hide_header Strict-Transport-Security;
       proxy_hide_header Vary;
       proxy_set_header Host $host;
       proxy_pass https://{{ frontend_nginx_flatpak_origin }};

--- a/roles/frontend/templates/nginx-conf.d-flatpak-ssl.conf.j2
+++ b/roles/frontend/templates/nginx-conf.d-flatpak-ssl.conf.j2
@@ -9,7 +9,6 @@ server {
 
     location / {
       proxy_cache frontend_cache;
-      proxy_hide_header Vary;
       proxy_set_header Host $host;
       proxy_pass https://{{ frontend_nginx_flatpak_origin }};
     }

--- a/roles/frontend/templates/nginx-conf.d-webroot-default.conf.j2
+++ b/roles/frontend/templates/nginx-conf.d-webroot-default.conf.j2
@@ -5,7 +5,6 @@ server {
 
     location /.well-known/acme-challenge {
       proxy_pass http://{{ frontend_nginx_webroot_origin }}/.well-known/acme-challenge;
-      proxy_hide_header Strict-Transport-Security;
       proxy_hide_header Vary;
     }
 

--- a/roles/frontend/templates/nginx-conf.d-webroot-default.conf.j2
+++ b/roles/frontend/templates/nginx-conf.d-webroot-default.conf.j2
@@ -5,7 +5,6 @@ server {
 
     location /.well-known/acme-challenge {
       proxy_pass http://{{ frontend_nginx_webroot_origin }}/.well-known/acme-challenge;
-      proxy_hide_header Vary;
     }
 
     location / {

--- a/roles/frontend/templates/nginx-default.d-webroot.conf.j2
+++ b/roles/frontend/templates/nginx-default.d-webroot.conf.j2
@@ -9,7 +9,6 @@ location / {
 
     proxy_intercept_errors on;
 
-    proxy_hide_header Strict-Transport-Security;
     proxy_hide_header Vary;
     proxy_set_header Host $host;
 

--- a/roles/frontend/templates/nginx-default.d-webroot.conf.j2
+++ b/roles/frontend/templates/nginx-default.d-webroot.conf.j2
@@ -9,7 +9,6 @@ location / {
 
     proxy_intercept_errors on;
 
-    proxy_hide_header Vary;
     proxy_set_header Host $host;
 
     if ($prerender = 1) {

--- a/roles/repo-manager/tasks/main.yml
+++ b/roles/repo-manager/tasks/main.yml
@@ -113,6 +113,17 @@
   tags:
    - repo-manager
 
+- name: install nginx default.d/repo.conf
+  template:
+    src: nginx-default.d-repo.conf.j2
+    dest: /etc/nginx/default.d/repo.conf
+    mode: 0644
+  notify:
+   - reload nginx
+  tags:
+    - repo-manager
+    - repo-manager_nginx
+
 - name: install nginx conf.d/repo-manager.conf
   template:
     src: nginx-conf.d-repo-manager.conf.j2

--- a/roles/repo-manager/templates/nginx-conf.d-repo-manager-ssl.conf.j2
+++ b/roles/repo-manager/templates/nginx-conf.d-repo-manager-ssl.conf.j2
@@ -4,9 +4,6 @@ server {
 
     server_name {{ repo_manager_domain }};
 
-    # Load common SSL options
-    include /etc/nginx/default.d/ssl.conf;
-
     # certs sent to the client in SERVER HELLO are concatenated in ssl_certificate
     ssl_certificate /etc/dehydrated/certs/{{ repo_manager_domain }}/fullchain.pem;
     ssl_certificate_key /etc/dehydrated/certs/{{ repo_manager_domain }}/privkey.pem;
@@ -14,103 +11,6 @@ server {
     ## verify chain of trust of OCSP response using Root CA and Intermediate certs
     ssl_trusted_certificate /etc/dehydrated/certs/{{ repo_manager_domain }}/chain.pem;
 
-    location /repo {
-        alias {{ repo_manager_repodir }};
-        add_header Cache-Control "public";
-        expires 1h;
-
-        location ~ ^/repo/summary(\.sig)?$ {
-            add_header Surrogate-Control "stale-if-error=86400";
-        }
-
-       location /repo/refs {
-            add_header Surrogate-Control "stale-if-error=86400";
-            expires 1m;
-       }
-       location ~ ^/repo/objects/.+\.commitmeta$ {
-           expires 1d;
-           access_log off;
-       }
-       location ~ ^/repo/objects/.+\.(sig|sizes2)$ {
-           return 404;
-           expires 1y;
-           access_log off;
-       }
-       location ~ ^/repo/objects/.+\.(commit|dirtree|filez)$ {
-           expires 1y;
-           access_log off;
-       }
-       location /repo/deltas {
-           expires 1y;
-           access_log off;
-       }
-       location /repo/sources {
-           autoindex on;
-       }
-       location /repo/sources/downloads {
-           expires 1y;
-           access_log off;
-           autoindex on;
-       }
-       location /repo/appstream {
-           autoindex on;
-       }
-    }
-
-    location /beta-repo {
-        alias {{ repo_manager_beta_repodir }};
-        add_header Cache-Control "public";
-        expires 1h;
-
-        location ~ ^/beta-repo/summary(\.sig)?$ {
-            add_header Surrogate-Control "stale-if-error=86400";
-        }
-
-       location /beta-repo/refs {
-            add_header Surrogate-Control "stale-if-error=86400";
-            expires 1m;
-       }
-       location ~ ^/beta-repo/objects/.+\.commitmeta$ {
-           expires 1d;
-           access_log off;
-       }
-       location ~ ^/beta-repo/objects/.+\.(sig|sizes2)$ {
-           return 404;
-           expires 1y;
-           access_log off;
-       }
-       location ~ ^/beta-repo/objects/.+\.(commit|dirtree|filez)$ {
-           expires 1y;
-           access_log off;
-       }
-       location /beta-repo/deltas {
-           expires 1y;
-           access_log off;
-       }
-       location /beta-repo/sources {
-           autoindex on;
-       }
-       location /beta-repo/sources/downloads {
-           expires 1y;
-           access_log off;
-           autoindex on;
-       }
-       location /beta-repo/appstream {
-           autoindex on;
-       }
-    }
-
-    location /build-repo {
-        proxy_pass http://127.0.0.1:8080;
-   }
-
-    location /api {
-        # Allow uploading large builds, deltas, etc
-        client_max_body_size 0;
-        proxy_pass http://127.0.0.1:8080;
-    }
-
-    location / {
-        deny all;
-    }
+    # load default configs
+    include /etc/nginx/default.d/*.conf;
 }

--- a/roles/repo-manager/templates/nginx-conf.d-repo-manager.conf.j2
+++ b/roles/repo-manager/templates/nginx-conf.d-repo-manager.conf.j2
@@ -7,8 +7,6 @@ server {
     # Accept Let's Encrypt challenges for dehydrated
     include /etc/nginx/default.d/dehydrated.conf;
 
-    # Otherwise, redirect to https://
-    location / {
-        return 301 https://$host$request_uri;
-    }
+    # Proxy repos
+    include /etc/nginx/default.d/repo.conf;
 }

--- a/roles/repo-manager/templates/nginx-default.d-repo.conf.j2
+++ b/roles/repo-manager/templates/nginx-default.d-repo.conf.j2
@@ -1,0 +1,113 @@
+location /repo {
+    alias {{ repo_manager_repodir }};
+    add_header Cache-Control "public";
+    expires 1h;
+
+    location ~ ^/repo/summary(\.sig)?$ {
+        add_header Surrogate-Control "stale-if-error=86400";
+    }
+
+    location /repo/refs {
+        add_header Surrogate-Control "stale-if-error=86400";
+        expires 1m;
+    }
+
+    location ~ ^/repo/objects/.+\.commitmeta$ {
+        expires 1d;
+        access_log off;
+    }
+
+    location ~ ^/repo/objects/.+\.(sig|sizes2)$ {
+        return 404;
+        expires 1y;
+        access_log off;
+    }
+
+    location ~ ^/repo/objects/.+\.(commit|dirtree|filez)$ {
+        expires 1y;
+        access_log off;
+    }
+
+    location /repo/deltas {
+        expires 1y;
+        access_log off;
+    }
+
+    location /repo/sources {
+        autoindex on;
+    }
+
+    location /repo/sources/downloads {
+        expires 1y;
+        access_log off;
+        autoindex on;
+    }
+
+    location /repo/appstream {
+        autoindex on;
+    }
+}
+
+location /beta-repo {
+    alias {{ repo_manager_beta_repodir }};
+    add_header Cache-Control "public";
+    expires 1h;
+
+    location ~ ^/beta-repo/summary(\.sig)?$ {
+        add_header Surrogate-Control "stale-if-error=86400";
+    }
+
+    location /beta-repo/refs {
+        add_header Surrogate-Control "stale-if-error=86400";
+        expires 1m;
+    }
+
+    location ~ ^/beta-repo/objects/.+\.commitmeta$ {
+        expires 1d;
+        access_log off;
+    }
+
+    location ~ ^/beta-repo/objects/.+\.(sig|sizes2)$ {
+        return 404;
+        expires 1y;
+        access_log off;
+    }
+
+    location ~ ^/beta-repo/objects/.+\.(commit|dirtree|filez)$ {
+        expires 1y;
+        access_log off;
+    }
+
+    location /beta-repo/deltas {
+        expires 1y;
+        access_log off;
+    }
+
+    location /beta-repo/sources {
+        autoindex on;
+    }
+
+    location /beta-repo/sources/downloads {
+        expires 1y;
+        access_log off;
+        autoindex on;
+    }
+
+    location /beta-repo/appstream {
+        autoindex on;
+    }
+}
+
+location /build-repo {
+    proxy_pass http://127.0.0.1:8080;
+}
+
+location /api {
+    # Allow uploading large builds, deltas, etc
+    client_max_body_size 0;
+    proxy_pass http://127.0.0.1:8080;
+}
+
+location / {
+    deny all;
+}

--- a/roles/repo-manager/templates/nginx-default.d-repo.conf.j2
+++ b/roles/repo-manager/templates/nginx-default.d-repo.conf.j2
@@ -100,12 +100,14 @@ location /beta-repo {
 
 location /build-repo {
     proxy_pass http://127.0.0.1:8080;
+    add_header Vary Accept-Encoding;
 }
 
 location /api {
     # Allow uploading large builds, deltas, etc
     client_max_body_size 0;
     proxy_pass http://127.0.0.1:8080;
+    add_header Vary Accept-Encoding;
 }
 
 location / {


### PR DESCRIPTION
Serve /repo and friends with both HTTP and HTTPS, clear duplicate HSTS headers, allow Vary: header to propagate correctly (if necessary we should sanitise Accept-Encoding on the CDN frontend) and add the missing Vary header on responses from the proxy-manager.