### PR TITLE
Work around flat-manager permission issue

### DIFF
--- a/roles/repo-manager/templates/nginx-default.d-repo.conf.j2
+++ b/roles/repo-manager/templates/nginx-default.d-repo.conf.j2
@@ -107,7 +107,7 @@ location /api {
     # Allow uploading large builds, deltas, etc
     client_max_body_size 0;
     proxy_pass http://127.0.0.1:8080;
-    proxy_read_timeout 600s;
+    proxy_read_timeout 6000s;
     add_header Vary Accept-Encoding;
 }
 

--- a/roles/repo-manager/templates/post-publish.sh.j2
+++ b/roles/repo-manager/templates/post-publish.sh.j2
@@ -4,6 +4,9 @@ REPODIR="$2"
 
 set -e
 
+# Work around issue with flat-manager getting the permissions wrong (not group readable + dictories executable)
+chmod -R a+rX /srv/repo/$REPONAME/screenshots /srv/repo/$REPONAME/deltas
+
 # purge intermediate front-* caches and then CDN
 # (Fastly-Soft-Purge is a no-op on front-*)
 if [ $REPONAME == "stable" ]; then

--- a/roles/repo-manager/templates/post-publish.sh.j2
+++ b/roles/repo-manager/templates/post-publish.sh.j2
@@ -5,7 +5,8 @@ REPODIR="$2"
 set -e
 
 # Work around issue with flat-manager getting the permissions wrong (not group readable + dictories executable)
-chmod -R a+rX /srv/repo/$REPONAME/screenshots /srv/repo/$REPONAME/deltas
+find /srv/repo/$REPONAME/screenshots ! -perm -og+rX -exec chmod go+rX {} \;
+find /srv/repo/$REPONAME/deltas  ! -perm -og+rX -exec chmod go+rX {} \;
 
 # purge intermediate front-* caches and then CDN
 # (Fastly-Soft-Purge is a no-op on front-*)


### PR DESCRIPTION
It seems like we're experiencing issues with permissions, with some
delta files and extracted screenshot directores not being world accessible.
This is a temporary workaround. I will make the real fix in flat-manager.