### PR TITLE
roles/base: comment mythic-backup cronjob when backups disabled

### DIFF
--- a/roles/base/tasks/mythic.yml
+++ b/roles/base/tasks/mythic.yml
@@ -69,3 +69,10 @@
     src: mythic-backup.conf.j2
     dest: /etc/mythic/backup.conf
     mode: 0644
+
+- name: update mythic-backup cronjob
+  lineinfile:
+    path: /etc/cron.d/mythic-backup
+    regexp: '^#?(.*/usr/sbin/mythic-backup.*)$'
+    line: '{{ base_mythic_backup_disabled | ternary("#", "") }}\1'
+    backrefs: yes


### PR DESCRIPTION
DISABLED=yes in the mythic-backup config file sends a warning e-mail nightly
that backups are disabled. Avoid the noise by also disabling the cronjob - but
leave the configuration so that the backup can't be manually started either.