### PR TITLE
Add trailing slash to repo URLs

### DIFF
--- a/host_vars/hub.flathub.org
+++ b/host_vars/hub.flathub.org
@@ -29,10 +29,10 @@ repo_manager_build_gpg_key: 4184DD4D907A7CAE
 
 repo_manager_collection_id: "org.flathub.Stable"
 repo_manager_main_gpg_key: 4184DD4D907A7CAE
-repo_manager_main_base_url: "https://dl.flathub.org/repo"
+repo_manager_main_base_url: "https://dl.flathub.org/repo/"
 repo_manager_suggested_repo_name: "flathub"
 
 repo_manager_beta_collection_id: "org.flathub.Beta"
 repo_manager_beta_gpg_key: 4184DD4D907A7CAE
-repo_manager_beta_base_url: "https://dl.flathub.org/beta-repo"
+repo_manager_beta_base_url: "https://dl.flathub.org/beta-repo/"
 repo_manager_suggested_beta_repo_name: "flathub-beta"


### PR DESCRIPTION
We should have a trailing slash on the URL used in flatpakref files, so
it matches the one in the flatpakrepo file. Otherwise flatpak tries to
add duplicate remotes; see
https://github.com/flatpak/flatpak/issues/2979

Fixes https://github.com/flathub/flathub/issues/905