### PR TITLE
Add PATH to crontab for mythic-reporter

### DIFF
--- a/misc/get-vault-pass.sh
+++ b/misc/get-vault-pass.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-exec gpg2 --batch --decrypt --quiet $(dirname $0)/vault-password.gpg
+for i in gpg2 gpg; do GPG=$i; which $i >/dev/null && break; done
+
+exec ${GPG} --batch --decrypt --quiet $(dirname $0)/vault-password.gpg

--- a/misc/reencrypt-vault-pass.sh
+++ b/misc/reencrypt-vault-pass.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-exec gpg2 --batch --decrypt $(dirname $0)/vault-password.gpg | gpg --armor --recipient 487328A9 --recipient E06F63B5 --recipient B76C70E9 --recipient C7EC6914  -e -o $(dirname $0)/vault-password.gpg
+for i in gpg2 gpg; do GPG=$i; which $i >/dev/null && break; done
+
+exec ${GPG} --batch --decrypt $(dirname $0)/vault-password.gpg | gpg --armor --recipient 487328A9 --recipient E06F63B5 --recipient B76C70E9 --recipient C7EC6914  -e -o $(dirname $0)/vault-password.gpg

--- a/roles/base/tasks/mythic.yml
+++ b/roles/base/tasks/mythic.yml
@@ -80,3 +80,11 @@
     regexp: '^#?(.*/usr/sbin/mythic-backup.*)$'
     line: '{{ base_mythic_backup_disabled | ternary("#", "") }}\1'
     backrefs: yes
+
+- name: set PATH for mythic-reporter cronjob
+  cron:
+    user: root
+    cron_file: mythic-reporter
+    env: yes
+    name: PATH
+    value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin


### PR DESCRIPTION
Ubuntu systems seem not to have sbin in the PATH for root's crontabs.
Set it manually to avoid errors from ufw when called by the
mythic-reporter.