### PR TITLE
buildbot-worker: Add p7zip-full to buildbot packages

### DIFF
--- a/roles/buildbot-worker/tasks/main.yml
+++ b/roles/buildbot-worker/tasks/main.yml
@@ -20,6 +20,7 @@
       - flatpak-builder
       - python-setuptools
       - git-lfs
+      - p7zip-full
     state: latest
 
 - name: create buildbot user


### PR DESCRIPTION
For 7z archive source in flatpak-builder, need a 7z binary  
https://github.com/flatpak/flatpak-builder/pull/323
```c
  gboolean res;
  const gchar *argv[] = { "7z",  "x", sevenz_path, NULL };
  res = flatpak_spawnv (dir, NULL, 0, error, argv);
```
The 7z format is not auto detected, need to add `archive-type: 7z` manually  

`p7zip` only contain 7zr, `p7zip-full` contains 7z.  

Tested bot(failed without 7z) on https://flathub.org/builds/#/builders/32/builds/71118